### PR TITLE
Prevent duplicate Step crash

### DIFF
--- a/Pod/Core/Step.swift
+++ b/Pod/Core/Step.swift
@@ -143,7 +143,9 @@ class Step: Hashable, Equatable, CustomDebugStringConvertible {
 }
 
 func ==(lhs: Step, rhs: Step) -> Bool {
-    return lhs.expression == rhs.expression
+    return lhs.expression == rhs.expression &&
+           lhs.file == rhs.file &&
+           lhs.line == rhs.line
 }
 
 extension Collection where Element == Step {


### PR DESCRIPTION
Prevent the tests from crashing due to duplicate steps being added in the Set.

Updated the `Step` Hashable definition to ensure that the equatable properties are correctly checked for matches.
